### PR TITLE
fix: completion failure when cursor is on the last line

### DIFF
--- a/server/src/language_service/parsers/pkd_parser.ts
+++ b/server/src/language_service/parsers/pkd_parser.ts
@@ -165,7 +165,7 @@ export class PkdParser {
     let text = textDocument.getText();
     if (line > -1) {
       const start = textDocument.offsetAt({ line, character: 0 });
-      const end = textDocument.offsetAt({ line: line + 1, character: 0 }) - 1;
+      const end = textDocument.offsetAt({ line, character: Infinity });
       text =
         text.substring(0, start) +
         " ".repeat(end - start) +


### PR DESCRIPTION
Change `omitLineFromText()` to compute the end position of the line to be replaced using `{line: character: Infinity}` instead of using `{line: line + 1, character: 0} - 1`. The latter gives an error when the cursor is on the last line.