### PR TITLE
fix: apply syntax highlighting to entries beginning with `-` only

### DIFF
--- a/syntaxes/peekingduck.tmLanguage.json
+++ b/syntaxes/peekingduck.tmLanguage.json
@@ -93,39 +93,11 @@
           ]
         },
         {
-          "begin": "(?x)\n  (?=\n    (?x:\n        [^\\s[-?:,\\[\\]{}#&*!|>'\\\"%@`]]\n      | [?:-] \\S\n    )\n    (\n        [^\\s:]\n      | : \\S\n      | \\s+ (?![#\\s])\n    )*\n    \\s*\n    :\n    (\\s|$)\n  )\n",
+          "begin": "(?x)\n  (?=\n    (?x:\n        [^\\s[-?:,\\[\\]{}#&*!|>'\\\"%@`]]\n      | [?:-] \\S\n    )\n    (\n        [^\\s:]\n      | : \\S\n      | \\s+ (?![#\\s])\n    )*\n    \\s* : (\\s|$)\n  )\n",
           "end": "(?x)\n  (?=\n      \\s* $\n    | \\s+ \\#\n    | \\s* : (\\s|$)\n  )\n",
           "patterns": [
             {
               "include": "#flow-scalar-plain-out-implicit-type"
-            },
-            {
-              "match": "(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
-              "captures": {
-                "1": {
-                  "name": "storage.type.node.peekingduck"
-                },
-                "2": {
-                  "name": "punctuation.separator.node-name"
-                }
-              }
-            },
-            {
-              "match": "([\\w\\d]+)(\\.)(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
-              "captures": {
-                "1": {
-                  "name": "entity.name.namespace.peekingduck-custom"
-                },
-                "2": {
-                  "name": "punctuation.separator.node-name"
-                },
-                "3": {
-                  "name": "storage.type.node.peekingduck-custom"
-                },
-                "4": {
-                  "name": "punctuation.separator.node-name"
-                }
-              }
             },
             {
               "begin": "(?x)\n    [^\\s[-?:,\\[\\]{}#&*!|>'\\\"%@`]]\n  | [?:-] \\S\n",
@@ -496,32 +468,38 @@
           "include": "#flow-scalar-plain-out-implicit-type"
         },
         {
-          "match": "(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
-          "captures": {
-            "1": {
-              "name": "storage.type.node.peekingduck"
+          "begin": "(?<=^\\s*-)",
+          "end": "(?x)\n  (?=\n      \\s* $\n    | \\s+ \\#\n    | \\s* : (\\s|$)\n  )\n",
+          "patterns": [
+            {
+              "match": "(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
+              "captures": {
+                "1": {
+                  "name": "storage.type.node.peekingduck"
+                },
+                "2": {
+                  "name": "punctuation.separator.node-name"
+                }
+              }
             },
-            "2": {
-              "name": "punctuation.separator.node-name"
+            {
+              "match": "([\\w\\d]+)(\\.)(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
+              "captures": {
+                "1": {
+                  "name": "entity.name.namespace.peekingduck-custom"
+                },
+                "2": {
+                  "name": "punctuation.separator.node-name"
+                },
+                "3": {
+                  "name": "storage.type.node.peekingduck-custom"
+                },
+                "4": {
+                  "name": "punctuation.separator.node-name"
+                }
+              }
             }
-          }
-        },
-        {
-          "match": "([\\w\\d]+)(\\.)(augment|dabble|draw|input|model|output)(\\.)[\\w\\d]+",
-          "captures": {
-            "1": {
-              "name": "entity.name.namespace.peekingduck-custom"
-            },
-            "2": {
-              "name": "punctuation.separator.node-name"
-            },
-            "3": {
-              "name": "storage.type.node.peekingduck-custom"
-            },
-            "4": {
-              "name": "punctuation.separator.node-name"
-            }
-          }
+          ]
         },
         {
           "begin": "(?x)\n    [^\\s[-?:,\\[\\]{}#&*!|>'\"%@`]]\n  | [?:-] \\S\n",

--- a/syntaxes/peekingduck.tmLanguage.yml
+++ b/syntaxes/peekingduck.tmLanguage.yml
@@ -57,9 +57,7 @@ repository:
                 | : \S
                 | \s+ (?![#\s])
               )*
-              \s*
-              :
-              (\s|$)
+              \s* : (\s|$)
             )
         end: >
           (?x)
@@ -70,22 +68,6 @@ repository:
             )
         patterns:
           - include: "#flow-scalar-plain-out-implicit-type"
-          - match: (augment|dabble|draw|input|model|output)(\.)[\w\d]+
-            captures:
-              "1":
-                name: storage.type.node.peekingduck
-              "2":
-                name: punctuation.separator.node-name
-          - match: ([\w\d]+)(\.)(augment|dabble|draw|input|model|output)(\.)[\w\d]+
-            captures:
-              "1":
-                name: entity.name.namespace.peekingduck-custom
-              "2":
-                name: punctuation.separator.node-name
-              "3":
-                name: storage.type.node.peekingduck-custom
-              "4":
-                name: punctuation.separator.node-name
           - begin: >
               (?x)
                   [^\s[-?:,\[\]{}#&*!|>'\"%@`]]
@@ -401,22 +383,31 @@ repository:
   flow-scalar-plain-out:
     patterns:
       - include: "#flow-scalar-plain-out-implicit-type"
-      - match: (augment|dabble|draw|input|model|output)(\.)[\w\d]+
-        captures:
-          "1":
-            name: storage.type.node.peekingduck
-          "2":
-            name: punctuation.separator.node-name
-      - match: ([\w\d]+)(\.)(augment|dabble|draw|input|model|output)(\.)[\w\d]+
-        captures:
-          "1":
-            name: entity.name.namespace.peekingduck-custom
-          "2":
-            name: punctuation.separator.node-name
-          "3":
-            name: storage.type.node.peekingduck-custom
-          "4":
-            name: punctuation.separator.node-name
+      - begin: (?<=^\s*-)
+        end: >
+          (?x)
+            (?=
+                \s* $
+              | \s+ \#
+              | \s* : (\s|$)
+            )
+        patterns:
+          - match: (augment|dabble|draw|input|model|output)(\.)[\w\d]+
+            captures:
+              "1":
+                name: storage.type.node.peekingduck
+              "2":
+                name: punctuation.separator.node-name
+          - match: ([\w\d]+)(\.)(augment|dabble|draw|input|model|output)(\.)[\w\d]+
+            captures:
+              "1":
+                name: entity.name.namespace.peekingduck-custom
+              "2":
+                name: punctuation.separator.node-name
+              "3":
+                name: storage.type.node.peekingduck-custom
+              "4":
+                name: punctuation.separator.node-name
       - begin: >
           (?x)
               [^\s[-?:,\[\]{}#&*!|>'"%@`]]


### PR DESCRIPTION
Current implementation highlights config values too if they match the PeekingDuck node definition pattern, e.g., `input.mp4`
![image](https://user-images.githubusercontent.com/56420072/182269723-b351caf6-77bc-43fa-8aca-2f1a619afd99.png)

The changes introduced in this PR restrict the PeekingDuck node definition syntax highlight to only entries which begins with `-`. 
![image](https://user-images.githubusercontent.com/56420072/182269868-1b58d87c-db28-482a-a1f5-5fea0a0fb7eb.png)
